### PR TITLE
Fixes link parsing

### DIFF
--- a/helpers/linkify.js
+++ b/helpers/linkify.js
@@ -1,8 +1,13 @@
 var Handlebars = require('handlebars');
+var Autolinker = require('autolinker');
+
 module.exports = function(text, options) {
   text = text.string || text;
 
-  var newText = text.replace(/(https?:\/\/(?:www\.|(?!www))[^\s\.]+\.[^\s]{2,}|www\.[^\s]+\.[^\s]{2,})/gi, '<a href="$1" target="_blank">$1</a>');
+  var linkedText = Autolinker.link(text, {
+    newWindow: true,
+    phone: false
+  });
 
-  return new Handlebars.SafeString(newText);
+  return new Handlebars.SafeString(linkedText);
 };

--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
   },
   "dependencies": {
     "aug": "0.1.0",
+    "autolinker": "0.17.1",
     "catbox-mongodb": "1.1.0",
     "confi": "0.6.0",
     "good": "^6.1.0",


### PR DESCRIPTION
Fixes a problem where links like www.google.com would not link correctly. The autolink lib not only parses urls correctly but adds a bunch of other cool things we use a lot, like twitter parsing.

https://github.com/gregjacobs/Autolinker.js