### PR TITLE
Upgrade to hapi 11 and update all deps

### DIFF
--- a/conf/default-plugins.yaml
+++ b/conf/default-plugins.yaml
@@ -3,7 +3,9 @@ authPlugins:
     _nativePlugin: true
 plugins:
   vision:
+    _nativePlugin: true
   inert:
+    _nativePlugin: true
   good-mongodb-viewer:
     _nativePlugin: true
     connectionUrl: '{{mongo.url}}'

--- a/conf/default-plugins.yaml
+++ b/conf/default-plugins.yaml
@@ -2,6 +2,8 @@ authPlugins:
   hapi-password:
     _nativePlugin: true
 plugins:
+  vision:
+  inert:
   good-mongodb-viewer:
     _nativePlugin: true
     connectionUrl: '{{mongo.url}}'

--- a/conf/default-strategies.yaml
+++ b/conf/default-strategies.yaml
@@ -4,6 +4,7 @@ strategies:
     mode: false
     options:
       password: '{{admin.password}}'
+      salt: 'salt'
       endpoint: '/admin/login'
       successEndpont: '/admin'
       cookieName: '{{name}}-admin'

--- a/conf/default.yaml
+++ b/conf/default.yaml
@@ -42,8 +42,6 @@ assets:
   cors:
     origin:
       - '{{fullHost}}'
-    methods:
-      - 'GET'
     exposedHeaders: []
   cache:
     privacy: 'public'

--- a/example/index.js
+++ b/example/index.js
@@ -1,7 +1,9 @@
-var Rapptor = require('../');
-var Boom = require('boom');
+'use strict';
 
-var rapptor = new Rapptor({
+const Rapptor = require('../');
+const Boom = require('boom');
+
+const rapptor = new Rapptor({
   cwd: __dirname
 });
 
@@ -14,4 +16,3 @@ rapptor.server.route({
 });
 
 rapptor.start();
-

--- a/example/jobs/testJob.js
+++ b/example/jobs/testJob.js
@@ -1,3 +1,5 @@
+'use strict';
+
 module.exports = function(data, done) {
   this.log(['agenda', 'job'], 'Test Job');
   done();

--- a/example/methods/getTime.js
+++ b/example/methods/getTime.js
@@ -1,14 +1,12 @@
+'use strict';
+
 module.exports = {
-  method: function(next) {
-    return next(null, new Date());
-  },
+  method: (next) => next(null, new Date()),
   options: {
     cache: {
       expiresIn: 60 * 60 * 1000,
       generateTimeout: 400
     },
-    generateKey: function() {
-      return 'getTimeExample';
-    }
+    generateKey: () => 'getTimeExample'
   }
 };

--- a/example/methods/getTime.js
+++ b/example/methods/getTime.js
@@ -4,7 +4,8 @@ module.exports = {
   },
   options: {
     cache: {
-      expiresIn: 60 * 60 * 1000
+      expiresIn: 60 * 60 * 1000,
+      generateTimeout: 400
     },
     generateKey: function() {
       return 'getTimeExample';

--- a/example/methods/ns/getData.js
+++ b/example/methods/ns/getData.js
@@ -1,16 +1,20 @@
+'use strict';
+
 module.exports = {
   method: function(x, y, z, next) {
     if(x === 0 || y === 0) {
-      next('Lengths can\'t be 0');
+      return next('Lengths can\'t be 0');
     }
-    var cbe = (x * x) + (y * y);
-    var xbe = (z * z);
 
-    var ret = {
+    let cbe = (x * x) + (y * y);
+    let xbe = (z * z);
+
+    let ret = {
       cbe: cbe,
       xbe: xbe,
       triple: (cbe == xbe)
     };
+
     return next(null, ret);
   }
 }

--- a/example/methods/ns/getValues.js
+++ b/example/methods/ns/getValues.js
@@ -1,9 +1,11 @@
+'use strict';
+
 module.exports = {
   method: function(x, y, z, next) {
-    
-    var oneVal = x + " kings of spain";
-    var twoVal = y + " kings of greece";
-    var threeVal = z + " kings of all";
+
+    let oneVal = x + " kings of spain";
+    let twoVal = y + " kings of greece";
+    let threeVal = z + " kings of all";
 
     ret = {
       one: oneVal,

--- a/example/routes/cache.js
+++ b/example/routes/cache.js
@@ -1,11 +1,11 @@
+'use strict';
+
 exports.cache = {
   path: '/cache',
   method: 'GET',
   handler: {
     outputCache: {
-      fn: function(request, reply) {
-        reply(new Date());
-      }
+      fn: (request, reply) => reply(new Date())
     }
   }
 };

--- a/example/routes/home.js
+++ b/example/routes/home.js
@@ -1,8 +1,9 @@
+'use strict';
+
 exports.home = {
   method: 'GET',
-  path: '/', 
+  path: '/',
   handler: function(request, reply) {
-
     request.server.plugins.metrics.add('testing', { isTest: true }, function(err, metric) {
       reply.view('test/view');
     });

--- a/example/routes/time.js
+++ b/example/routes/time.js
@@ -1,9 +1,9 @@
+'use strict';
+
 exports.time = {
   method: 'GET',
-  path: '/time', 
+  path: '/time',
   handler: function(request, reply) {
-    request.server.methods.getTime(function(err, result){
-      reply(result);
-    });
+    request.server.methods.getTime((err, result) => reply(result));
   }
 };

--- a/helpers/all.js
+++ b/helpers/all.js
@@ -1,8 +1,10 @@
-module.exports = function () {
-  var passing = true;
-  var options = arguments[arguments.length-1];
+'use strict';
 
-  for (var i = 0, c = arguments.length; i < c; i++) {
+module.exports = function () {
+  const options = arguments[arguments.length-1];
+  let passing = true;
+
+  for (let i = 0, c = arguments.length; i < c; i++) {
     if (!arguments[i]) {
       passing = false;
       break;

--- a/helpers/asset.js
+++ b/helpers/asset.js
@@ -1,15 +1,17 @@
-var url = require('url');
-var Handlebars = require('handlebars');
+'use strict';
+
+const url = require('url');
+const Handlebars = require('handlebars');
 
 module.exports = function (type, filename, version) {
   if (!filename) {
     return;
   }
 
-  var cdn = this._server.app.config.assets.host || '';
+  const cdn = this._server.app.config.assets.host || '';
   version = (typeof version === 'string') ? version : this._server.app.config.assets.version;
 
-  var file;
+  let file;
 
   if (type == 'image' || type == 'image-path') {
     file = filename;
@@ -17,13 +19,14 @@ module.exports = function (type, filename, version) {
     file = this._server.methods.getAsset(filename, type);
   }
 
-  var filePath = url.resolve(cdn, this._server.app.config.assets.path) + '/' + file;
+  let filePath = url.resolve(cdn, this._server.app.config.assets.path) + '/' + file;
 
   if (version) {
     filePath += '?v=' + version;
   }
 
-  var out = '';
+  let out = '';
+
   if (type == 'css') {
     out = '<link rel="stylesheet" href="'+filePath+'"/>';
   } else if (type == 'js') {
@@ -33,6 +36,6 @@ module.exports = function (type, filename, version) {
   } else if (type == 'image-path') {
     out = filePath;
   }
-  
+
   return new Handlebars.SafeString(out);
 };

--- a/helpers/escaper.js
+++ b/helpers/escaper.js
@@ -1,8 +1,11 @@
-var Handlebars = require('handlebars');
+'use strict';
+
+const Handlebars = require('handlebars');
+
 module.exports = function(text, options) {
   text = text.string || text;
 
-  var newText = Handlebars.Utils.escapeExpression(text);
+  let newText = Handlebars.Utils.escapeExpression(text);
 
   return new Handlebars.SafeString(newText);
 };

--- a/helpers/greaterthan.js
+++ b/helpers/greaterthan.js
@@ -1,5 +1,6 @@
+'use strict';
+
 module.exports = function (val1, val2, options) {
-  var context = (options.fn.contexts && options.fn.contexts[0]) || this;
   if(val1 && typeof val1 === 'object') {
     val1 = val1.toString();
   }

--- a/helpers/ifequal.js
+++ b/helpers/ifequal.js
@@ -1,5 +1,6 @@
+'use strict';
+
 module.exports = function (val1, val2, options) {
-  var context = (options.fn.contexts && options.fn.contexts[0]) || this;
   if(val1 && typeof val1 === 'object') {
     val1 = val1.toString();
   }

--- a/helpers/ifnotequal.js
+++ b/helpers/ifnotequal.js
@@ -1,5 +1,6 @@
+'use strict';
+
 module.exports = function (val1, val2, options) {
-  var context = (options.fn.contexts && options.fn.contexts[0]) || this;
   if (val1 !== val2) {
     return options.fn(this);
   } else{

--- a/helpers/indexof.js
+++ b/helpers/indexof.js
@@ -1,5 +1,6 @@
+'use strict';
+
 module.exports = function (val1, val2, options) {
-  var context = (options.fn.contexts && options.fn.contexts[0]) || this;
   if (val1.indexOf(val2) !== -1) {
     return options.fn(this);
   } else{

--- a/helpers/linkify.js
+++ b/helpers/linkify.js
@@ -1,10 +1,12 @@
-var Handlebars = require('handlebars');
-var Autolinker = require('autolinker');
+'use strict';
+
+const Handlebars = require('handlebars');
+const Autolinker = require('autolinker');
 
 module.exports = function(text, options) {
   text = text.string || text;
 
-  var linkedText = Autolinker.link(text, {
+  let linkedText = Autolinker.link(text, {
     newWindow: true,
     phone: false
   });

--- a/helpers/nl2br.js
+++ b/helpers/nl2br.js
@@ -1,7 +1,9 @@
-var Handlebars = require('handlebars');
+'use strict';
+
+const Handlebars = require('handlebars');
 module.exports = function(text) {
   text = text.string || text;
 
-  var nl2br = (text + '').replace(/([^>\r\n]?)(\r\n|\n\r|\r|\n)/g, '$1' + ' <br>' + '$2');
+  let nl2br = (text + '').replace(/([^>\r\n]?)(\r\n|\n\r|\r|\n)/g, '$1' + ' <br>' + '$2');
   return new Handlebars.SafeString(nl2br);
 };

--- a/helpers/stringify.js
+++ b/helpers/stringify.js
@@ -1,8 +1,12 @@
-var Handlebars = require('handlebars');
+'use strict';
+
+const Handlebars = require('handlebars');
 module.exports = function(input, pretty) {
-  var spaces = (pretty) ? '  ' : '';
+  const spaces = (pretty) ? '  ' : '';
+
   if (input._server) {
     delete input._server;
   }
+
   return new Handlebars.SafeString(JSON.stringify(input, null, spaces));
 };

--- a/index.js
+++ b/index.js
@@ -1,11 +1,13 @@
-var loadConfig = require('confi');
-var Hapi = require('hapi');
-var _ = require('lodash');
-var fs = require('fs');
-var path = require('path');
-var async = require('async');
+'use strict';
 
-var Rapptor = function(options) {
+const loadConfig = require('confi');
+const Hapi = require('hapi');
+const _ = require('lodash');
+const fs = require('fs');
+const path = require('path');
+const async = require('async');
+
+const Rapptor = function(options) {
   options = options || {};
 
   this.cwd = options.cwd || process.cwd();
@@ -13,7 +15,8 @@ var Rapptor = function(options) {
   //load up config
   this._setupConfig();
 
-  var serverConfig = _.cloneDeep(this.config.server);
+  const serverConfig = _.cloneDeep(this.config.server);
+
   serverConfig.app = this.config;
   serverConfig.cache = {
     engine: require('catbox-mongodb'),
@@ -34,12 +37,10 @@ var Rapptor = function(options) {
   this._readPlugins(this.config.authPlugins, 'authPlugins');
   this._readPlugins(this.config.plugins, 'plugins');
 
-
   this.server.connection(this.config.connection);
 };
 
 Rapptor.prototype._setupConfig = function() {
-
   //rapptor defaults
   this.config = loadConfig({
     path: [
@@ -65,28 +66,30 @@ Rapptor.prototype._setupConfig = function() {
 };
 
 Rapptor.prototype._readPlugins = function(arr, type) {
-
-  var self = this;
-  _.forIn(arr, function(value, key) {
+  _.forIn(arr, (value, key) => {
     value = value || {};
+
     if (value._enabled === false) {
       return;
     }
+
     if (!value._nativePlugin) {
       if (key[0] == '.') {
-        key = path.join(self.cwd, key);
+        key = path.join(this.cwd, key);
       } else {
-        key = path.join(self.cwd, 'node_modules', key);
+        key = path.join(this.cwd, 'node_modules', key);
       }
     }
+
     delete value._enabled;
     delete value._nativePlugin;
-    self.loadPlugin(key, value, type);
+
+    this.loadPlugin(key, value, type);
   });
 };
 
 Rapptor.prototype._setupLogging = function() {
-  var reporters = [];
+  const reporters = [];
 
   _.forIn(this.config.logging.reporters, function(values, key) {
     if (values === false || values._enabled === false) {
@@ -111,6 +114,7 @@ Rapptor.prototype.loadPlugin = function(key, options, type) {
   if (!type) {
     type = 'plugins';
   }
+
   this[type].push({
     register: require(key),
     options: options
@@ -118,12 +122,13 @@ Rapptor.prototype.loadPlugin = function(key, options, type) {
 };
 
 Rapptor.prototype._setupViews = function() {
-  var self = this;
-  var viewPath = path.join(this.cwd, this.config.structure.views);
+  const viewPath = path.join(this.cwd, this.config.structure.views);
+
   if (!fs.existsSync(viewPath)) {
     return;
   }
-  var viewConfig = {
+
+  const viewConfig = {
     engines: {
       html: this.server.app.handlebars
     },
@@ -133,33 +138,31 @@ Rapptor.prototype._setupViews = function() {
 
   this.server.views(viewConfig);
 
-  this.server.ext('onPreResponse', function(request, reply) {
-    var response = request.response;
-    var path = request.path;
+  this.server.ext('onPreResponse', (request, reply) => {
+    const response = request.response;
+    const path = request.path;
 
     if (response.variety === 'view') {
+      const context = response.source.context || {};
 
-      var context = response.source.context || {};
+      context.env = this.config.env;
 
-      context.env = self.config.env;
-
-      if (typeof self.getViewData === 'function') {
-        self.getViewData(context, request, self.config);
+      if (typeof this.getViewData === 'function') {
+        this.getViewData(context, request, this.config);
       }
+
       response.source.context = context;
 
       if (request.query.json == '1') {
         return reply(response.source.context);
       }
-
-    } else if (response.isBoom && self.config.views.errors) {
-
-      if (self.config.views.errorBlacklist && path.match(new RegExp(self.config.views.errorBlacklist))) {
+    } else if (response.isBoom && this.config.views.errors) {
+      if (this.config.views.errorBlacklist && path.match(new RegExp(this.config.views.errorBlacklist))) {
         return reply.continue();
       }
 
       if (response.output.statusCode == 500) {
-        self.server.log(['error'], {
+        this.server.log(['error'], {
           output: response.output,
           path: request.path,
           method: request.method,
@@ -168,9 +171,9 @@ Rapptor.prototype._setupViews = function() {
         });
       }
 
-      var payload = response.output.payload;
+      const payload = response.output.payload;
 
-      return reply.view(self.config.views.errors, {
+      return reply.view(this.config.views.errors, {
         statusCode: response.output.statusCode,
         error: payload.error,
         message: payload.message
@@ -182,28 +185,28 @@ Rapptor.prototype._setupViews = function() {
 };
 
 Rapptor.prototype._setupAssets = function() {
-
   if (this.config.assets.mapping) {
-    var assetPath = path.join(this.cwd, this.config.structure.assets, this.config.assets.mapping);
+    const assetPath = path.join(this.cwd, this.config.structure.assets, this.config.assets.mapping);
+
     if (fs.existsSync(assetPath)) {
       this.config.assets.mappingObj = require(assetPath);
     }
   }
+
   if (!this.config.assets.mappingObj) {
     this.config.assets.mappingObj = {};
   }
 
-  var self = this;
   this.server.route({
-    path: self.config.assets.path+'/{path*}',
+    path: this.config.assets.path+'/{path*}',
     method: 'GET',
     config: {
       auth: false,
-      cors: self.config.assets.cors,
-      cache: self.config.assets.cache,
+      cors: this.config.assets.cors,
+      cache: this.config.assets.cache,
       handler: {
         directory: {
-          path: path.resolve(self.cwd, self.config.structure.assets),
+          path: path.resolve(this.cwd, this.config.structure.assets),
           listing: false,
           index: false
         }
@@ -213,74 +216,62 @@ Rapptor.prototype._setupAssets = function() {
 };
 
 Rapptor.prototype._setupStrategies = function() {
-
-  var self = this;
-  _.forIn(this.config.strategies, function(value, name) {
-    self.server.auth.strategy(name, value.scheme, value.mode, value.options);
+  _.forIn(this.config.strategies, (value, name) => {
+    this.server.auth.strategy(name, value.scheme, value.mode, value.options)
   });
-
 };
 
 Rapptor.prototype.setup = function(callback) {
-  var self = this;
-
   async.waterfall([
-    function(done) {
-      self.server.register(self.authPlugins, done);
-    },
-    function(done) {
-      self._setupStrategies();
+    done => this.server.register(this.authPlugins, done),
+    done => {
+      this._setupStrategies();
       done();
     },
-    function(done) {
-      self.server.register(self.plugins, done);
-    },
-    function(done) {
-      self.server.plugins['hapi-auto-loader'].load({
+    done => this.server.register(this.plugins, done),
+    done => {
+      this.server.plugins['hapi-auto-loader'].load({
         cwd: __dirname,
         routes: false,
         partials: false
       }, done);
     },
-    function(done) {
-      self.server.plugins['hapi-auto-loader'].load({
-        cwd: self.cwd,
+    done => {
+      this.server.plugins['hapi-auto-loader'].load({
+        cwd: this.cwd,
         routes: {
-          path: self.config.structure.routes,
-          base: self.config.routes.base,
-          context: self.config.routes.context
+          path: this.config.structure.routes,
+          base: this.config.routes.base,
+          context: this.config.routes.context
         },
         partials: {
-          path: self.config.structure.partials
+          path: this.config.structure.partials
         },
         helpers: {
-          path: self.config.structure.helpers
+          path: this.config.structure.helpers
         },
         methods: {
-          path: self.config.structure.methods
+          path: this.config.structure.methods
         }
       }, done);
     },
-    function(done) {
-      self._setupViews();
-      self._setupAssets();
-      done(null, self.server);
-    },
-
-
+    done => {
+      this._setupViews();
+      this._setupAssets();
+      done(null, this.server);
+    }
   ], callback);
 };
 
 Rapptor.prototype.callMethod = function(server, method, argv, callback) {
-
   callback = callback || _.noop;
 
-  var methodFunc = _.get(server.methods, method);
+  const methodFunc = _.get(server.methods, method);
 
   if(methodFunc) {
-    var funcArgs = argv;
+    const funcArgs = argv;
 
-    for(var i=0; i<funcArgs.length; i++){
+    for(let i=0; i<funcArgs.length; i++){
       try {
         funcArgs[i] = JSON.parse(funcArgs[i]);
       } catch(e) {
@@ -310,7 +301,6 @@ Rapptor.prototype.callMethod = function(server, method, argv, callback) {
 }
 
 Rapptor.prototype.start = function(callback) {
-
   callback = callback || _.noop;
 
   this.setup(function(err, server){
@@ -318,10 +308,10 @@ Rapptor.prototype.start = function(callback) {
       return callback(err);
     }
 
-    var args = process.argv.slice(2);
+    const args = process.argv.slice(2);
 
     if(args.shift() == 'method') {
-      var method = args.shift();
+      const method = args.shift();
       Rapptor.prototype.callMethod(server, method, args, callback);
     } else {
       server.start(function(err) {

--- a/methods/getAsset.js
+++ b/methods/getAsset.js
@@ -1,9 +1,11 @@
-var path = require('path');
+'use strict';
+
+const path = require('path');
 
 module.exports = {
   method: function(basename, type) {
-    var filename = basename + '.' + type;
-    var assetFile = this.app.config.assets.mappingObj[filename] || filename;
+    const filename = basename + '.' + type;
+    const assetFile = this.app.config.assets.mappingObj[filename] || filename;
     return path.join(this.app.config.assets.compiled, assetFile);
   }
 };

--- a/package.json
+++ b/package.json
@@ -40,5 +40,8 @@
   },
   "devDependencies": {
     "boom": "3.0.0"
+  },
+  "engines": {
+    "node": ">=4.0.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -14,29 +14,31 @@
     "url": "https://github.com/firstandthird/rapptor.git"
   },
   "dependencies": {
-    "async": "1.2.1",
-    "autolinker": "0.17.1",
-    "catbox-mongodb": "1.1.0",
-    "confi": "0.7.0",
-    "good": "6.1.4",
-    "good-console": "5.0.2",
+    "async": "1.5.0",
+    "autolinker": "0.22.0",
+    "catbox-mongodb": "1.1.2",
+    "confi": "0.8.0",
+    "good": "6.4.0",
+    "good-console": "5.2.0",
     "good-hipchat": "0.4.0",
     "good-mongodb": "0.4.0",
-    "good-mongodb-viewer": "0.8.1",
-    "handlebars": "3.0.3",
-    "hapi": "8.6.1",
+    "good-mongodb-viewer": "0.9.1",
+    "handlebars": "4.0.4",
+    "hapi": "11.1.0",
     "hapi-agenda": "0.9.1",
     "hapi-auto-loader": "0.6.0",
     "hapi-log-response": "0.1.0",
     "hapi-metrics": "3.0.0",
     "hapi-output-cache": "0.3.0",
-    "hapi-password": "0.3.0",
-    "hapi-redirects": "0.1.0",
-    "joi": "6.4.3",
-    "lodash": "3.9.3",
-    "require-all": "1.1.0"
+    "hapi-password": "0.5.0",
+    "hapi-redirects": "1.0.1",
+    "inert": "^3.2.0",
+    "joi": "7.0.0",
+    "lodash": "3.10.1",
+    "require-all": "2.0.0",
+    "vision": "^4.0.1"
   },
   "devDependencies": {
-    "boom": "2.7.2"
+    "boom": "3.0.0"
   }
 }

--- a/readme.md
+++ b/readme.md
@@ -3,12 +3,17 @@
 ### Usage:
 
 ```js
-var Rapptor = require('rapptor');
-var rapptor = new Rapptor();
+const Rapptor = require('rapptor');
+const rapptor = new Rapptor();
 rapptor.start();
 ```
 
 see example directory for a working app.
+
+### Backwards breaking changes
+
+ - Rapptor now requires nodejs > v4
+ - Some core Hapi plugins might require initializing via plugin config
 
 ### Using in tests
 


### PR DESCRIPTION
There might be some older bundled hapi plugins that need to be loaded in since hapi ripped just about everything out into smaller plugins. I got the example up and running with pretty little effort.

Maybe now we can start to use all the cool new stuff.

I went ahead and updated rapptor to use some of the new es6 syntax since Hapi does already.
